### PR TITLE
fix encoding bug when using some other codepage

### DIFF
--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -292,7 +292,7 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
 
         filename = dlg.filename
         newline = '' if isinstance(fmt, CSVFormat) else None
-        with io.open(filename, 'w', newline=newline, encoding="utf-8") as f:
+        with io.open(filename, 'w', newline=newline, encoding='utf-8') as f:
             f.write(fmt.format(cutlist))
 
         ui.messageBox(f'Export complete: {filename}', COMMAND_NAME)

--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -292,7 +292,7 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
 
         filename = dlg.filename
         newline = '' if isinstance(fmt, CSVFormat) else None
-        with io.open(filename, 'w', newline=newline) as f:
+        with io.open(filename, 'w', newline=newline, encoding="utf-8") as f:
             f.write(fmt.format(cutlist))
 
         ui.messageBox(f'Export complete: {filename}', COMMAND_NAME)


### PR DESCRIPTION
when one is using a code page that is not ascii or UTF-8 and uses some "strange" chars like šđčćž in the naming of the bodies or components the export will throw an error and it will not export:

![2023-11-07 00_26_28-ExportCutlist](https://github.com/bluekeyes/Fusion360-ExportCutlist/assets/5629345/120ba601-1ed0-4c95-81d4-3db5004efde9)

This PR fixes the problem.