### PR TITLE
Allow setting dimension unit at export time

### DIFF
--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -150,7 +150,7 @@ class CutList:
 
         elif isinstance(obj, adsk.fusion.Occurrence):
             if obj.isReferencedComponent and self.ignoreexternal:
-                return 
+                return
             for body in obj.bRepBodies:
                 self.add_body(body, self._joinname(name, obj.component.name, body.name))
             for child in obj.childOccurrences:
@@ -228,9 +228,8 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
 
         unitInput = advancedGroup.children.addDropDownCommandInput('unit', 'Output unit', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
         unitInput.tooltip = 'Units for output dimensions'
-        for fmt in ALL_UNITS:
-            formatInput.listItems.add(fmt, preferences['unit'] == fmt, '')
-            unitInput.listItems.add(fmt, preferences['unit'] == fmt, '')
+        for unit in ALL_UNITS:
+            unitInput.listItems.add(unit, preferences['unit'] == unit, '')
 
         axisAlignedInput = advancedGroup.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', preferences['axisAligned'])
         axisAlignedInput.tooltip = 'If checked, use axis-algined bounding boxes.'
@@ -328,7 +327,6 @@ def set_preferences_from_inputs(inputs: adsk.core.CommandInputs):
     preferences['format'] = formatInput.selectedItem.name
     preferences['axisAligned'] = axisAlignedInput.value
     preferences['tolerance'] = toleranceInput.value
-    preferences['unit'] = unitInput.value
     preferences['unit'] = unitInput.selectedItem.name
 
 @report_errors

--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -23,6 +23,11 @@ COMMAND_NAME = 'Export Cutlist'
 
 DEFAULT_TOLERANCE = 1e-04
 DEFAULT_GROUPBY = GroupBy(dimensions=True, material=True)
+DEFAULT_UNIT = 'auto'
+
+ALL_UNITS = [
+  'auto', 'in', 'mm'
+]
 
 # required to keep handlers in scope
 handlers = []
@@ -33,6 +38,7 @@ preferences = {
     'ignoreExternal': False,
     'groupBy': DEFAULT_GROUPBY,
     'format': TableFormat.name,
+    'unit': DEFAULT_UNIT,
     'axisAligned': False,
     'tolerance': DEFAULT_TOLERANCE,
 }
@@ -220,6 +226,12 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         advancedGroup.isEnabledCheckBoxDisplayed = False
         advancedGroup.isExpanded = False
 
+        unitInput = advancedGroup.children.addDropDownCommandInput('unit', 'Output unit', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
+        unitInput.tooltip = 'Units for output dimensions'
+        for fmt in ALL_UNITS:
+            formatInput.listItems.add(fmt, preferences['unit'] == fmt, '')
+            unitInput.listItems.add(fmt, preferences['unit'] == fmt, '')
+
         axisAlignedInput = advancedGroup.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', preferences['axisAligned'])
         axisAlignedInput.tooltip = 'If checked, use axis-algined bounding boxes.'
         axisAlignedInput.tooltipDescription = 'This disables the rotation heuristic and assumes parts are already in the ideal orientation relative to the X, Y, and Z axes.'
@@ -281,7 +293,7 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
             cutlist.add(selectionInput.selection(i).entity)
 
         fmt_class = get_format(preferences['format'])
-        fmt = fmt_class(design.unitsManager, doc.name)
+        fmt = fmt_class(design.unitsManager, doc.name, units=preferences['unit'])
 
         dlg = ui.createFileDialog()
         dlg.title = 'Save Cutlist'
@@ -304,6 +316,7 @@ def set_preferences_from_inputs(inputs: adsk.core.CommandInputs):
     formatInput: adsk.core.DropDownCommandInput = inputs.itemById('format')
     axisAlignedInput: adsk.core.BoolValueCommandInput = inputs.itemById('axisaligned')
     toleranceInput: adsk.core.ValueCommandInput = inputs.itemById('tolerance')
+    unitInput: adsk.core.DropDownCommandInput = inputs.itemById('unit')
 
     dimensionsInput: adsk.core.BoolValueCommandInput = inputs.itemById('group_dimensions')
     materialInput: adsk.core.BoolValueCommandInput = inputs.itemById('group_material')
@@ -315,7 +328,8 @@ def set_preferences_from_inputs(inputs: adsk.core.CommandInputs):
     preferences['format'] = formatInput.selectedItem.name
     preferences['axisAligned'] = axisAlignedInput.value
     preferences['tolerance'] = toleranceInput.value
-
+    preferences['unit'] = unitInput.value
+    preferences['unit'] = unitInput.selectedItem.name
 
 @report_errors
 def run(context):

--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -26,7 +26,7 @@ DEFAULT_GROUPBY = GroupBy(dimensions=True, material=True)
 DEFAULT_UNIT = 'auto'
 
 ALL_UNITS = [
-  'auto', 'in', 'mm'
+  'auto', 'in', 'ft', 'mm', 'cm', 'm'
 ]
 
 # required to keep handlers in scope

--- a/lib/format.py
+++ b/lib/format.py
@@ -27,7 +27,7 @@ class Format:
     def __init__(self, unitsMgr: adsk.core.UnitsManager, docname: str, units=None):
         self.unitsMgr = unitsMgr
         self.docname = docname
-        self.units = units if units else unitsMgr.defaultLengthUnits
+        self.units = units if (units and units != 'auto') else unitsMgr.defaultLengthUnits
 
     @property
     def filename(self):


### PR DESCRIPTION
Adds an option under advanced to allow setting the unit to a different value than the document format.