### PR TITLE
Fix import failure for CutlistOptimizer

### DIFF
--- a/lib/format.py
+++ b/lib/format.py
@@ -111,12 +111,15 @@ class CutlistOptimizerFormat(CSVFormat):
         return ['Length', 'Width', 'Qty', 'Label', 'Enabled']
 
     def item_to_dict(self, item):
+        # Note that CutlistOptimizer uses str.split to 'parse' the fields in each record. Import will
+        # fail when fields contain the delimiter. Use semicolon to separate the names and remove all
+        # delimiters from str values.
         fields = self.fieldnames
         return {
             fields[0]: self.format_value(item.dimensions.length),
             fields[1]: self.format_value(item.dimensions.width),
             fields[2]: item.count,
-            fields[3]: ','.join(item.names),
+            fields[3]: ';'.join(item.names).replace(',', ''),
             fields[4]: 'true'
         }
 


### PR DESCRIPTION
https://cutlistoptimizer.com/ uses JavaScript's string split function to 'parse' the fields in each record. This results in an import failure when fields contain the delimiter.