### PR TITLE
Move cutlist types to a dedicated module

### DIFF
--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -12,18 +12,13 @@ import functools
 import io
 import traceback
 
-from operator import attrgetter
-from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import adsk.core
 import adsk.fusion
 
 from .lib.format import ALL_FORMATS, TableFormat, CSVFormat, get_format
-from .lib.geometry.bodies import MinimalBody, get_minimal_body
-
-
-GroupBy = namedtuple('GroupBy', ['dimensions', 'material'])
+from .lib.cutlist import GroupBy, CutList, CutListOptions
 
 
 COMMAND_ID = 'ExportCutlistCommand'
@@ -42,22 +37,15 @@ handlers = []
 
 
 @dataclass
-class CutListOptions:
-    ignore_hidden: bool = True
-    ignore_external: bool = False
-    axis_aligned: bool = False
-
-    group_by: GroupBy = DEFAULT_GROUPBY
-
+class Options:
+    cutlist: CutListOptions = field(default_factory=CutListOptions)
+    name_separator: str = '/'
     format: str = TableFormat.name
     unit: str = DEFAULT_UNIT
-    name_separator: str = '/'
-
-    tolerance: float = DEFAULT_TOLERANCE
 
 
 # Remember user options in between creations of the command
-user_options = CutListOptions()
+user_options = Options()
 
 
 def report_errors(func):
@@ -74,129 +62,6 @@ def report_errors(func):
             app.userInterface.messageBox(f'Failed:\n{traceback.format_exc()}')
 
     return wrapper
-
-
-class Dimensions:
-    tolerance = DEFAULT_TOLERANCE
-
-    @classmethod
-    def from_body(cls, body: MinimalBody):
-        bbox = body.bounding_box
-        x = bbox.maxPoint.x - bbox.minPoint.x
-        y = bbox.maxPoint.y - bbox.minPoint.y
-        z = bbox.maxPoint.z - bbox.minPoint.z
-        return cls(x, y, z)
-
-    def __init__(self, x, y, z):
-        ordered = tuple(sorted((x, y, z)))
-        self.length = ordered[2]
-        self.width = ordered[1]
-        self.height = ordered[0]
-
-    def __eq__(self, other):
-        if isinstance(other, Dimensions):
-            return (abs(self.length - other.length) < Dimensions.tolerance and
-                    abs(self.width - other.width) < Dimensions.tolerance and
-                    abs(self.height - other.height) < Dimensions.tolerance)
-        return NotImplemented
-
-
-class CutListItem:
-    def __init__(self, body: MinimalBody, name: str):
-        self.names = [name]
-        self.dimensions = Dimensions.from_body(body)
-        self.material = body.material.name
-
-    @property
-    def count(self):
-        return len(self.names)
-
-    def matches(self, other, group: GroupBy):
-        if isinstance(other, CutListItem):
-            other_dimensions = other.dimensions
-            other_material = other.material
-        elif isinstance(other, MinimalBody):
-            other_dimensions = Dimensions.from_body(other)
-            other_material = other.material.name
-        else:
-            return False
-
-        if group.dimensions:
-            if self.dimensions != other_dimensions:
-                return False
-            if group.material and self.material != other_material:
-                return False
-            return True
-
-        return False
-
-    def add_instance(self, name):
-        self.names.append(name)
-
-
-class CutList:
-    def __init__(self, options: CutListOptions):
-        self.items: list[CutListItem] = []
-
-        self.group = options.group_by
-        self.ignorehidden = options.ignore_hidden
-        self.ignoreexternal = options.ignore_external
-        self.axisaligned = options.axis_aligned
-        self.namesep = options.name_separator
-
-    def add_body(self, body: adsk.fusion.BRepBody, name: str):
-        if not body.isSolid:
-            return
-
-        if not body.isVisible and self.ignorehidden:
-            return
-
-        if self.axisaligned:
-            minimal_body = MinimalBody(body)
-        else:
-            minimal_body = get_minimal_body(body)
-
-        added = False
-        for item in self.items:
-            if item.matches(minimal_body, self.group):
-                item.add_instance(name)
-                added = True
-                break
-
-        if not added:
-            item = CutListItem(minimal_body, name)
-            self.items.append(item)
-
-    def add(self, obj, name=None):
-        if isinstance(obj, adsk.fusion.BRepBody):
-            self.add_body(obj, self._joinname(name, obj.name))
-
-        elif isinstance(obj, adsk.fusion.Occurrence):
-            if obj.isReferencedComponent and self.ignoreexternal:
-                return
-            for body in obj.bRepBodies:
-                self.add_body(body, self._joinname(name, obj.component.name, body.name))
-            for child in obj.childOccurrences:
-                self.add(child, self._joinname(name, obj.component.name))
-
-        elif isinstance(obj, adsk.fusion.Component):
-            for body in obj.bRepBodies:
-                self.add_body(body, self._joinname(name, obj.name, body.name))
-            for occ in obj.occurrences:
-                self.add(occ, self._joinname(name, obj.name))
-
-        else:
-            raise ValueError(f'Cannot add object with type: {obj.objectType}')
-
-    def sorted_items(self):
-        items = list(self.items)
-        items.sort(key=lambda i: attrgetter('length', 'width', 'height')(i.dimensions), reverse=True)
-        items.sort(key=attrgetter('count'), reverse=True)
-        items.sort(key=attrgetter('material'))
-        return items
-
-    def _joinname(self, *parts):
-        return self.namesep.join([p for p in parts if p])
 
 
 class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
@@ -219,10 +84,10 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         select_input.addSelectionFilter('Occurrences')
         select_input.setSelectionLimits(0)
 
-        hidden_input = inputs.addBoolValueInput('hidden', 'Ignore hidden', True, '', user_options.ignore_hidden)
+        hidden_input = inputs.addBoolValueInput('hidden', 'Ignore hidden', True, '', user_options.cutlist.ignore_hidden)
         hidden_input.tooltip = 'If checked, hidden bodies are excluded from the cutlist.'
 
-        external_input = inputs.addBoolValueInput('external', 'Ignore external', True, '', user_options.ignore_external)
+        external_input = inputs.addBoolValueInput('external', 'Ignore external', True, '', user_options.cutlist.ignore_external)
         external_input.tooltip = 'If checked, external components are excluded from the cutlist.'
 
         format_input = inputs.addDropDownCommandInput('format', 'Output format', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
@@ -234,10 +99,10 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         grouping_group.isEnabledCheckBoxDisplayed = False
         grouping_group.isExpanded = True
 
-        dimensions_input = grouping_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.group_by.dimensions)
+        dimensions_input = grouping_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.cutlist.group_by.dimensions)
         dimensions_input.tooltip = 'If checked, group bodies by their dimensions.'
 
-        material_input = grouping_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.group_by.material)
+        material_input = grouping_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.cutlist.group_by.material)
         material_input.tooltip = 'If checked, group bodies by their material.'
         material_input.tooltipDescription = 'This option is only used when also grouping bodies by their dimensions.'
         material_input.isEnabled = dimensions_input.value
@@ -251,11 +116,11 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         for unit in ALL_UNITS:
             unit_input.listItems.add(unit, user_options.unit == unit, '')
 
-        axis_aligned_input = advanced_group.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', user_options.axis_aligned)
+        axis_aligned_input = advanced_group.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', user_options.cutlist.axis_aligned)
         axis_aligned_input.tooltip = 'If checked, use axis-algined bounding boxes.'
         axis_aligned_input.tooltipDescription = 'This disables the rotation heuristic and assumes parts are already in the ideal orientation relative to the X, Y, and Z axes.'
 
-        tolerance_input = advanced_group.children.addValueInput('tolerance', 'Tolerance', 'mm', adsk.core.ValueInput.createByReal(user_options.tolerance))
+        tolerance_input = advanced_group.children.addValueInput('tolerance', 'Tolerance', 'mm', adsk.core.ValueInput.createByReal(user_options.cutlist.tolerance))
         tolerance_input.tooltip = 'The tolerance used when matching bounding box dimensions.'
 
         execute_handler = CutlistCommandExecuteHandler()
@@ -291,10 +156,7 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
 
         set_options_from_inputs(inputs)
 
-        if user_options.tolerance > 0:
-            Dimensions.tolerance = user_options.tolerance
-
-        cutlist = CutList(user_options)
+        cutlist = CutList(user_options.cutlist)
 
         selection_input = inputs.itemById('selection')
         for i in range(selection_input.selectionCount):
@@ -330,12 +192,12 @@ def set_options_from_inputs(inputs: adsk.core.CommandInputs):
     material_input: adsk.core.BoolValueCommandInput = inputs.itemById('group_material')
     group_by = GroupBy(dimensions=dimensions_input.value, material=material_input.value)
 
-    user_options.ignore_hidden = hidden_input.value
-    user_options.ignore_external = external_input.value
-    user_options.group_by = group_by
+    user_options.cutlist.ignore_hidden = hidden_input.value
+    user_options.cutlist.ignore_external = external_input.value
+    user_options.cutlist.group_by = group_by
+    user_options.cutlist.axis_aligned = axis_aligned_input.value
+    user_options.cutlist.tolerance = tolerance_input.value
     user_options.format = format_input.selectedItem.name
-    user_options.axis_aligned = axis_aligned_input.value
-    user_options.tolerance = tolerance_input.value
     user_options.unit = unit_input.selectedItem.name
 
 

--- a/lib/cutlist.py
+++ b/lib/cutlist.py
@@ -1,0 +1,170 @@
+from dataclasses import dataclass
+from operator import attrgetter
+from typing import NamedTuple
+
+import adsk.fusion
+
+from .geometry.bodies import MinimalBody, get_minimal_body
+
+
+class GroupBy(NamedTuple):
+    """Identifies criteria by which to group bodies."""
+
+    dimensions: bool
+    material: bool
+
+
+class Dimensions(NamedTuple):
+    """
+    The dimensions (length, width, and height) for a body.
+
+    Dimensions are always in order of decreasing size, with length as the
+    largest, then width, then height.
+    """
+
+    length: float
+    width: float
+    height: float
+
+    @classmethod
+    def from_body(cls, body: MinimalBody):
+        bbox = body.bounding_box
+        x = bbox.maxPoint.x - bbox.minPoint.x
+        y = bbox.maxPoint.y - bbox.minPoint.y
+        z = bbox.maxPoint.z - bbox.minPoint.z
+        return cls.from_xyz(x, y, z)
+
+    @classmethod
+    def from_xyz(cls, x: float, y: float, z: float):
+        ordered = tuple(sorted((x, y, z)))
+        return cls(length=ordered[2], width=ordered[1], height=ordered[0])
+
+    def equal_with_tolerance(self, other, tolerance: float):
+        if isinstance(other, Dimensions):
+            return (abs(self.length - other.length) < tolerance and
+                    abs(self.width - other.width) < tolerance and
+                    abs(self.height - other.height) < tolerance)
+        return NotImplemented
+
+
+@dataclass
+class CutListOptions:
+    """
+    Options that affect cutlist generation.
+
+    Options:
+        ignore_hidden    ignore components that are hidden / not visible
+        ignore_external  ignore referenced components from other designs
+        axis_aligned     use axis-aligned bounding boxes instead of minimal bounding boxes
+        group_by         the criteria by which to group bodies
+        tolerance        the tolerance for matching dimensions
+    """
+
+    ignore_hidden: bool = True
+    ignore_external: bool = False
+    axis_aligned: bool = False
+    group_by: GroupBy = GroupBy(True, True)
+    tolerance: float = 1e-04
+
+
+class CutListItem:
+    def __init__(self, body: MinimalBody, name: str):
+        self.names = [name]
+        self.dimensions = Dimensions.from_body(body)
+        self.material = body.material.name
+
+    @property
+    def count(self):
+        return len(self.names)
+
+    def matches(self, other, group_by: GroupBy, tolerance: float):
+        if isinstance(other, CutListItem):
+            other_dimensions = other.dimensions
+            other_material = other.material
+        elif isinstance(other, MinimalBody):
+            other_dimensions = Dimensions.from_body(other)
+            other_material = other.material.name
+        else:
+            return False
+
+        if group_by.dimensions:
+            if not self.dimensions.equal_with_tolerance(other_dimensions, tolerance):
+                return False
+            if group_by.material and self.material != other_material:
+                return False
+            return True
+
+        return False
+
+    def add_instance(self, name):
+        self.names.append(name)
+
+
+class CutList:
+    def __init__(self, options: CutListOptions):
+        self.items: list[CutListItem] = []
+
+        self.ignore_hidden = options.ignore_hidden
+        self.ignore_external = options.ignore_external
+        self.axis_aligned = options.axis_aligned
+        self.group_by = options.group_by
+        self.tolerance = options.tolerance
+
+        self.namesep = '/' # TODO(bkeyes): names should only be concatenated on display
+
+    def add_body(self, body: adsk.fusion.BRepBody, name: str):
+        if not body.isSolid:
+            return
+
+        if not body.isVisible and self.ignore_hidden:
+            return
+
+        if self.axis_aligned:
+            minimal_body = MinimalBody(body)
+        else:
+            minimal_body = get_minimal_body(body)
+
+        added = False
+        for item in self.items:
+            if item.matches(minimal_body, self.group_by, self.tolerance):
+                item.add_instance(name)
+                added = True
+                break
+
+        if not added:
+            item = CutListItem(minimal_body, name)
+            self.items.append(item)
+
+    def add(self, obj, name=None):
+        # Body selected directly
+        if isinstance(obj, adsk.fusion.BRepBody):
+            self.add_body(obj, self._joinname(name, obj.name))
+
+        # Non-root component selected directly or as a child of another occurence
+        elif isinstance(obj, adsk.fusion.Occurrence):
+            if obj.isReferencedComponent and self.ignore_external:
+                return
+            for body in obj.bRepBodies:
+                self.add_body(body, self._joinname(name, obj.component.name, body.name))
+            for child in obj.childOccurrences:
+                self.add(child, self._joinname(name, obj.component.name))
+
+        # Root component selected directly
+        elif isinstance(obj, adsk.fusion.Component):
+            for body in obj.bRepBodies:
+                self.add_body(body, self._joinname(name, obj.name, body.name))
+            for occ in obj.occurrences:
+                self.add(occ, self._joinname(name, obj.name))
+
+        else:
+            raise ValueError(f'Cannot add object with type: {obj.objectType}')
+
+    def sorted_items(self):
+        items = list(self.items)
+        items.sort(key=lambda i: attrgetter('length', 'width', 'height')(i.dimensions), reverse=True)
+        items.sort(key=attrgetter('count'), reverse=True)
+        items.sort(key=attrgetter('material'))
+        return items
+
+    def _joinname(self, *parts):
+        return self.namesep.join([p for p in parts if p])


### PR DESCRIPTION
This leaves the root module with only the logic for interacting with Fusion, which should be easier to follow. It also removes the use of a global tolerance value in favor of passing the tolerance directly where needed.