### PR TITLE
Use consistent names for all selection methods

### DIFF
--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -156,11 +156,13 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
 
         set_options_from_inputs(inputs)
 
-        cutlist = CutList(user_options.cutlist)
-
+        selection = []
         selection_input = inputs.itemById('selection')
         for i in range(selection_input.selectionCount):
-            cutlist.add(selection_input.selection(i).entity)
+            selection.append(selection_input.selection(i).entity)
+
+        cutlist = CutList(user_options.cutlist)
+        cutlist.add(design.rootComponent, selection)
 
         fmt_class = get_format(user_options.format)
         fmt = fmt_class(design.unitsManager, doc.name, units=user_options.unit)

--- a/lib/cutlist.py
+++ b/lib/cutlist.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from operator import attrgetter
 from typing import NamedTuple
 
+import adsk.core
 import adsk.fusion
 
 from .geometry.bodies import MinimalBody, get_minimal_body
@@ -12,6 +13,22 @@ class GroupBy(NamedTuple):
 
     dimensions: bool
     material: bool
+
+
+class BodyPath(NamedTuple):
+    """The full path to a body from the document's root component."""
+
+    components: tuple[str]
+    body_name: str
+
+    @property
+    def parent_name(self):
+        if len(self.components) > 0:
+            return self.components[-1]
+        return ""
+
+    def path_str(self, separator="/"):
+        return separator.join((*self.components, self.body_name))
 
 
 class Dimensions(NamedTuple):
@@ -68,14 +85,14 @@ class CutListOptions:
 
 
 class CutListItem:
-    def __init__(self, body: MinimalBody, name: str):
-        self.names = [name]
+    def __init__(self, body: MinimalBody, path: BodyPath):
+        self.paths = [path]
         self.dimensions = Dimensions.from_body(body)
         self.material = body.material.name
 
     @property
     def count(self):
-        return len(self.names)
+        return len(self.paths)
 
     def matches(self, other, group_by: GroupBy, tolerance: float):
         if isinstance(other, CutListItem):
@@ -96,8 +113,8 @@ class CutListItem:
 
         return False
 
-    def add_instance(self, name):
-        self.names.append(name)
+    def add_instance(self, path):
+        self.paths.append(path)
 
 
 class CutList:
@@ -110,9 +127,50 @@ class CutList:
         self.group_by = options.group_by
         self.tolerance = options.tolerance
 
-        self.namesep = '/' # TODO(bkeyes): names should only be concatenated on display
+    def add(self, obj: adsk.core.Base, selection: list[adsk.core.Base], ancestors: list[str]=None, selected: bool=False):
+        """
+        Adds the selected bodies reachable from an object to the cutlist.
 
-    def add_body(self, body: adsk.fusion.BRepBody, name: str):
+        The selection set may contain bodies, occurences, or the root component.
+        Selecting an occurence or the root component also selects all bodies
+        that are associated with that entity or any child entity.
+
+        The initial call should include only the root component of the design
+        and the selection set. The remaining parameters are used as part of
+        recursive calls when decending through the design tree.
+        """
+        if ancestors is None:
+            ancestors = []
+
+        if isinstance(obj, adsk.fusion.BRepBody):
+            if selected or obj in selection:
+                self.add_body(obj, BodyPath(tuple(ancestors), obj.name))
+
+        elif isinstance(obj, adsk.fusion.Occurrence):
+            if obj.isReferencedComponent and self.ignore_external:
+                return
+
+            selected = selected or obj in selection
+            ancestors = [*ancestors, obj.component.name]
+
+            for child in [*obj.bRepBodies, *obj.childOccurrences]:
+                self.add(child, selection, ancestors, selected)
+
+        elif isinstance(obj, adsk.fusion.Component):
+            # The only component that should appear here is the root component.
+            # Exclude it from the ancestor list because it has the same name as
+            # the document and is not useful to include in the cutlist output.
+            selected = selected or obj in selection
+            for child in [*obj.bRepBodies, *obj.occurrences]:
+                self.add(child, selection, ancestors, selected)
+
+        else:
+            raise ValueError(f'Cannot add object with type: {obj.objectType}')
+
+    def add_body(self, body: adsk.fusion.BRepBody, path: BodyPath):
+        """
+        Adds a body to the cutlist, matching it against existing items.
+        """
         if not body.isSolid:
             return
 
@@ -127,37 +185,14 @@ class CutList:
         added = False
         for item in self.items:
             if item.matches(minimal_body, self.group_by, self.tolerance):
-                item.add_instance(name)
+                item.add_instance(path)
                 added = True
                 break
 
         if not added:
-            item = CutListItem(minimal_body, name)
+            item = CutListItem(minimal_body, path)
             self.items.append(item)
 
-    def add(self, obj, name=None):
-        # Body selected directly
-        if isinstance(obj, adsk.fusion.BRepBody):
-            self.add_body(obj, self._joinname(name, obj.name))
-
-        # Non-root component selected directly or as a child of another occurence
-        elif isinstance(obj, adsk.fusion.Occurrence):
-            if obj.isReferencedComponent and self.ignore_external:
-                return
-            for body in obj.bRepBodies:
-                self.add_body(body, self._joinname(name, obj.component.name, body.name))
-            for child in obj.childOccurrences:
-                self.add(child, self._joinname(name, obj.component.name))
-
-        # Root component selected directly
-        elif isinstance(obj, adsk.fusion.Component):
-            for body in obj.bRepBodies:
-                self.add_body(body, self._joinname(name, obj.name, body.name))
-            for occ in obj.occurrences:
-                self.add(occ, self._joinname(name, obj.name))
-
-        else:
-            raise ValueError(f'Cannot add object with type: {obj.objectType}')
 
     def sorted_items(self):
         items = list(self.items)
@@ -165,6 +200,3 @@ class CutList:
         items.sort(key=attrgetter('count'), reverse=True)
         items.sort(key=attrgetter('material'))
         return items
-
-    def _joinname(self, *parts):
-        return self.namesep.join([p for p in parts if p])

--- a/lib/format.py
+++ b/lib/format.py
@@ -8,6 +8,7 @@ import typing
 import adsk.core
 
 from .texttable import Texttable
+from .cutlist import CutList, CutListItem
 
 
 class FileFilter:
@@ -37,7 +38,10 @@ class Format:
     def format_value(self, value, showunits=False):
         return self.units_manager.formatInternalValue(value, self.units, showunits)
 
-    def format(self, cutlist):
+    def format_item_names(self, item: CutListItem):
+        return [p.path_str() for p in item.paths]
+
+    def format(self, cutlist: CutList):
         raise NotImplementedError
 
 
@@ -45,7 +49,7 @@ class JSONFormat(Format):
     name = 'JSON'
     filefilter = FileFilter('JSON Files', 'json')
 
-    def item_to_dict(self, item):
+    def item_to_dict(self, item: CutListItem):
         return {
             'count': item.count,
             'dimensions': {
@@ -55,10 +59,10 @@ class JSONFormat(Format):
                 'height': self.format_value(item.dimensions.height),
             },
             'material': item.material,
-            'names': item.names,
+            'names': self.format_item_names(item),
         }
 
-    def format(self, cutlist):
+    def format(self, cutlist: CutList):
         return json.dumps([self.item_to_dict(item) for item in cutlist.sorted_items()], indent=2)
 
 
@@ -80,7 +84,7 @@ class CSVFormat(Format):
             'names'
         ]
 
-    def item_to_dict(self, item):
+    def item_to_dict(self, item: CutListItem):
         fields = self.fieldnames
         return {
             fields[0]: item.count,
@@ -88,10 +92,10 @@ class CSVFormat(Format):
             fields[2]: self.format_value(item.dimensions.length),
             fields[3]: self.format_value(item.dimensions.width),
             fields[4]: self.format_value(item.dimensions.height),
-            fields[5]: ','.join(item.names),
+            fields[5]: ','.join(self.format_item_names(item)),
         }
 
-    def format(self, cutlist):
+    def format(self, cutlist: CutList):
         with io.StringIO(newline='') as f:
             w = csv.DictWriter(f, dialect=self.dialect, fieldnames=self.fieldnames)
             w.writeheader()
@@ -110,7 +114,7 @@ class CutlistOptimizerFormat(CSVFormat):
     def fieldnames(self):
         return ['Length', 'Width', 'Qty', 'Label', 'Enabled']
 
-    def item_to_dict(self, item):
+    def item_to_dict(self, item: CutListItem):
         # Note that CutlistOptimizer uses str.split to 'parse' the fields in each record. Import will
         # fail when fields contain the delimiter. Use semicolon to separate the names and remove all
         # delimiters from str values.
@@ -119,7 +123,7 @@ class CutlistOptimizerFormat(CSVFormat):
             fields[0]: self.format_value(item.dimensions.length),
             fields[1]: self.format_value(item.dimensions.width),
             fields[2]: item.count,
-            fields[3]: ';'.join(item.names).replace(',', ''),
+            fields[3]: ';'.join(self.format_item_names(item)).replace(',', ''),
             fields[4]: 'true'
         }
 
@@ -138,7 +142,7 @@ class CutlistEvoFormat(CSVFormat):
     def fieldnames(self):
         return ['Length', 'Width', 'Thickness', 'Quantity', 'Rotation', 'Name', 'Material', 'Banding']
 
-    def item_to_dict(self, item):
+    def item_to_dict(self, item: CutListItem):
         fields = self.fieldnames
         return {
             fields[0]: self.format_value(item.dimensions.length),
@@ -146,7 +150,7 @@ class CutlistEvoFormat(CSVFormat):
             fields[2]: self.format_value(item.dimensions.height),
             fields[3]: item.count,
             fields[4]: ','.join(['L'] * item.count),
-            fields[5]: ','.join(item.names),
+            fields[5]: ','.join(self.format_item_names(item)),
             fields[6]: item.material,
             fields[7]: ','.join(['N'] * item.count),
         }
@@ -160,17 +164,17 @@ class TableFormat(Format):
         lengthkey, widthkey, heightkey = [f'{v} ({self.units})' for v in ['length', 'width', 'height']]
         return ['count', 'material', lengthkey, widthkey, heightkey, 'names']
 
-    def item_to_row(self, item):
+    def item_to_row(self, item: CutListItem):
         return [
             item.count,
             item.material,
             self.format_value(item.dimensions.length),
             self.format_value(item.dimensions.width),
             self.format_value(item.dimensions.height),
-            '\n'.join(item.names),
+            '\n'.join(self.format_item_names(item)),
         ]
 
-    def format(self, cutlist):
+    def format(self, cutlist: CutList):
         tt = Texttable(max_width=0)
         tt.set_deco(Texttable.HEADER | Texttable.HLINES)
         tt.header(self.fieldnames)
@@ -189,18 +193,18 @@ class HTMLFormat(Format):
         lengthkey, widthkey, heightkey = [f'{v} ({self.units})' for v in ['Length', 'Width', 'Height']]
         return ['Count', lengthkey, widthkey, heightkey, 'Material', 'Names']
 
-    def item_to_row(self, item):
+    def item_to_row(self, item: CutListItem):
         cols = [
             item.count,
             self.format_value(item.dimensions.length),
             self.format_value(item.dimensions.width),
             self.format_value(item.dimensions.height),
             html.escape(item.material),
-            '<br>'.join(html.escape(n) for n in item.names),
+            '<br>'.join(html.escape(n) for n in self.format_item_names(item)),
         ]
         return '<tr>' + ''.join(f'<td>{c}</td>' for c in cols) + '</tr>'
 
-    def format(self, cutlist):
+    def format(self, cutlist: CutList):
         title = html.escape(self.docname)
         header = ''.join(f'<th>{html.escape(h)}</th>' for h in self.fieldnames)
         rows = ''.join(self.item_to_row(item) for item in cutlist.sorted_items())


### PR DESCRIPTION
Previously, the names of items changed based on how they were selected. Selecting bodies directly used only the body name, while selecting components included the component names as well. Selecting the root component would then include the document name and the name of all intermediate components.

In the the new model, we always exclude the root component and always name the item using the full path from the root, including all intermediate components. This means you can no longer get only body names, but I'll fix that with a future option.

This also fixes a bug where you could select both bodies and components and end up with duplicate items. This was particularly easy to do if you used drag selection and the origin was visible.

Fixes #20.
Also helps with #29 and #30, but those are not fully addressed until I add the extra options.