### PR TITLE
Add new formatting options

### DIFF
--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -89,19 +89,44 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         external_input = inputs.addBoolValueInput('external', 'Ignore external', True, '', user_options.cutlist_options.ignore_external)
         external_input.tooltip = 'If checked, external components are excluded from the cutlist.'
 
-        format_input = inputs.addDropDownCommandInput('format', 'Output format', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
+
+        format_group = inputs.addGroupCommandInput('format_group', 'Format')
+        format_group.isEnabledCheckBoxDisplayed = False
+        format_group.isExpanded = True
+
+        format_input = format_group.children.addDropDownCommandInput('format', 'Output format', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
         format_input.tooltip = 'The output format of the cutlist.'
         for fmt in ALL_FORMATS:
             format_input.listItems.add(fmt.name, user_options.format == fmt.name, '')
 
-        grouping_group = inputs.addGroupCommandInput('grouping', 'Group By')
-        grouping_group.isEnabledCheckBoxDisplayed = False
-        grouping_group.isExpanded = True
+        short_names_input = format_group.children.addBoolValueInput('short_names', 'Use short names', True, '', user_options.format_options.short_names)
+        short_names_input.tooltip = 'If checked, do not include the parents of a body or component in its name.'
 
-        dimensions_input = grouping_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.cutlist_options.group_by.dimensions)
+        component_names_input = format_group.children.addBoolValueInput('component_names', 'Use component names', True, '', user_options.format_options.component_names)
+        component_names_input.tooltip = 'If checked, use component names instead of body names.'
+
+        unique_names_input = format_group.children.addBoolValueInput('unique_names', 'Only output unique names', True, '', user_options.format_options.unique_names)
+        unique_names_input.tooltip = 'If checked, only include the unique names associated with each cutlist item.'
+
+        remove_numeric_input = format_group.children.addBoolValueInput('remove_numeric', 'Remove numeric suffixes', True, '', user_options.format_options.remove_numeric_suffixes)
+        remove_numeric_input.tooltip = 'If checked, remove common numeric suffixes from names.'
+
+        include_material_input = format_group.children.addBoolValueInput('include_material', 'Include material details', True, '', user_options.format_options.include_material)
+        include_material_input.tooltip = 'If checked, include material details in the output'
+        
+        unit_input = format_group.children.addDropDownCommandInput('unit', 'Output units', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
+        unit_input.tooltip = 'Units for output dimensions'
+        for units in ALL_UNITS:
+            unit_input.listItems.add(units, user_options.format_options.units == units, '')
+
+        group_by_group = inputs.addGroupCommandInput('group_by_group', 'Group By')
+        group_by_group.isEnabledCheckBoxDisplayed = False
+        group_by_group.isExpanded = True
+
+        dimensions_input = group_by_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.cutlist_options.group_by.dimensions)
         dimensions_input.tooltip = 'If checked, group bodies by their dimensions.'
 
-        material_input = grouping_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.cutlist_options.group_by.material)
+        material_input = group_by_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.cutlist_options.group_by.material)
         material_input.tooltip = 'If checked, group bodies by their material.'
         material_input.tooltipDescription = 'This option is only used when also grouping bodies by their dimensions.'
         material_input.isEnabled = dimensions_input.value
@@ -109,11 +134,6 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         advanced_group = inputs.addGroupCommandInput('advanced', 'Advanced Options')
         advanced_group.isEnabledCheckBoxDisplayed = False
         advanced_group.isExpanded = False
-
-        unit_input = advanced_group.children.addDropDownCommandInput('unit', 'Output unit', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
-        unit_input.tooltip = 'Units for output dimensions'
-        for units in ALL_UNITS:
-            unit_input.listItems.add(units, user_options.format_options.units == units, '')
 
         axis_aligned_input = advanced_group.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', user_options.cutlist_options.axis_aligned)
         axis_aligned_input.tooltip = 'If checked, use axis-algined bounding boxes.'
@@ -184,21 +204,34 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
 def set_options_from_inputs(inputs: adsk.core.CommandInputs):
     hidden_input: adsk.core.BoolValueCommandInput = inputs.itemById('hidden')
     external_input: adsk.core.BoolValueCommandInput = inputs.itemById('external')
+
     format_input: adsk.core.DropDownCommandInput = inputs.itemById('format')
-    axis_aligned_input: adsk.core.BoolValueCommandInput = inputs.itemById('axisaligned')
-    tolerance_input: adsk.core.ValueCommandInput = inputs.itemById('tolerance')
+    short_names_input: adsk.core.BoolValueCommandInput = inputs.itemById('short_names')
+    component_names_input: adsk.core.BoolValueCommandInput = inputs.itemById('component_names')
+    unique_names_input: adsk.core.BoolValueCommandInput = inputs.itemById('unique_names')
+    remove_numeric_input: adsk.core.BoolValueCommandInput = inputs.itemById('remove_numeric')
+    include_material_input: adsk.core.BoolValueCommandInput = inputs.itemById('include_material')
     unit_input: adsk.core.DropDownCommandInput = inputs.itemById('unit')
 
     dimensions_input: adsk.core.BoolValueCommandInput = inputs.itemById('group_dimensions')
     material_input: adsk.core.BoolValueCommandInput = inputs.itemById('group_material')
     group_by = GroupBy(dimensions=dimensions_input.value, material=material_input.value)
 
+    axis_aligned_input: adsk.core.BoolValueCommandInput = inputs.itemById('axisaligned')
+    tolerance_input: adsk.core.ValueCommandInput = inputs.itemById('tolerance')
+
     user_options.cutlist_options.ignore_hidden = hidden_input.value
     user_options.cutlist_options.ignore_external = external_input.value
     user_options.cutlist_options.group_by = group_by
     user_options.cutlist_options.axis_aligned = axis_aligned_input.value
     user_options.cutlist_options.tolerance = tolerance_input.value
+
     user_options.format = format_input.selectedItem.name
+    user_options.format_options.short_names = short_names_input.value
+    user_options.format_options.component_names = component_names_input.value
+    user_options.format_options.unique_names = unique_names_input.value
+    user_options.format_options.remove_numeric_suffixes = remove_numeric_input.value
+    user_options.format_options.include_material = include_material_input.value
     user_options.format_options.units = unit_input.selectedItem.name
 
 

--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -113,7 +113,7 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
 
         include_material_input = format_group.children.addBoolValueInput('include_material', 'Include material details', True, '', user_options.format_options.include_material)
         include_material_input.tooltip = 'If checked, include material details in the output'
-        
+
         unit_input = format_group.children.addDropDownCommandInput('unit', 'Output units', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
         unit_input.tooltip = 'Units for output dimensions'
         for units in ALL_UNITS:

--- a/ExportCutlist.py
+++ b/ExportCutlist.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 import adsk.core
 import adsk.fusion
 
-from .lib.format import ALL_FORMATS, TableFormat, CSVFormat, get_format
+from .lib.format import ALL_FORMATS, FormatOptions, TableFormat, CSVFormat, get_format
 from .lib.cutlist import GroupBy, CutList, CutListOptions
 
 
@@ -38,10 +38,9 @@ handlers = []
 
 @dataclass
 class Options:
-    cutlist: CutListOptions = field(default_factory=CutListOptions)
-    name_separator: str = '/'
+    cutlist_options: CutListOptions = field(default_factory=CutListOptions)
     format: str = TableFormat.name
-    unit: str = DEFAULT_UNIT
+    format_options: FormatOptions = field(default_factory=FormatOptions)
 
 
 # Remember user options in between creations of the command
@@ -84,10 +83,10 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         select_input.addSelectionFilter('Occurrences')
         select_input.setSelectionLimits(0)
 
-        hidden_input = inputs.addBoolValueInput('hidden', 'Ignore hidden', True, '', user_options.cutlist.ignore_hidden)
+        hidden_input = inputs.addBoolValueInput('hidden', 'Ignore hidden', True, '', user_options.cutlist_options.ignore_hidden)
         hidden_input.tooltip = 'If checked, hidden bodies are excluded from the cutlist.'
 
-        external_input = inputs.addBoolValueInput('external', 'Ignore external', True, '', user_options.cutlist.ignore_external)
+        external_input = inputs.addBoolValueInput('external', 'Ignore external', True, '', user_options.cutlist_options.ignore_external)
         external_input.tooltip = 'If checked, external components are excluded from the cutlist.'
 
         format_input = inputs.addDropDownCommandInput('format', 'Output format', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
@@ -99,10 +98,10 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
         grouping_group.isEnabledCheckBoxDisplayed = False
         grouping_group.isExpanded = True
 
-        dimensions_input = grouping_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.cutlist.group_by.dimensions)
+        dimensions_input = grouping_group.children.addBoolValueInput('group_dimensions', 'Dimensions', True, '', user_options.cutlist_options.group_by.dimensions)
         dimensions_input.tooltip = 'If checked, group bodies by their dimensions.'
 
-        material_input = grouping_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.cutlist.group_by.material)
+        material_input = grouping_group.children.addBoolValueInput('group_material', 'Material', True, '', user_options.cutlist_options.group_by.material)
         material_input.tooltip = 'If checked, group bodies by their material.'
         material_input.tooltipDescription = 'This option is only used when also grouping bodies by their dimensions.'
         material_input.isEnabled = dimensions_input.value
@@ -113,14 +112,14 @@ class CutlistCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
 
         unit_input = advanced_group.children.addDropDownCommandInput('unit', 'Output unit', adsk.core.DropDownStyles.LabeledIconDropDownStyle)
         unit_input.tooltip = 'Units for output dimensions'
-        for unit in ALL_UNITS:
-            unit_input.listItems.add(unit, user_options.unit == unit, '')
+        for units in ALL_UNITS:
+            unit_input.listItems.add(units, user_options.format_options.units == units, '')
 
-        axis_aligned_input = advanced_group.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', user_options.cutlist.axis_aligned)
+        axis_aligned_input = advanced_group.children.addBoolValueInput('axisaligned', 'Use axis-aligned boxes', True, '', user_options.cutlist_options.axis_aligned)
         axis_aligned_input.tooltip = 'If checked, use axis-algined bounding boxes.'
         axis_aligned_input.tooltipDescription = 'This disables the rotation heuristic and assumes parts are already in the ideal orientation relative to the X, Y, and Z axes.'
 
-        tolerance_input = advanced_group.children.addValueInput('tolerance', 'Tolerance', 'mm', adsk.core.ValueInput.createByReal(user_options.cutlist.tolerance))
+        tolerance_input = advanced_group.children.addValueInput('tolerance', 'Tolerance', 'mm', adsk.core.ValueInput.createByReal(user_options.cutlist_options.tolerance))
         tolerance_input.tooltip = 'The tolerance used when matching bounding box dimensions.'
 
         execute_handler = CutlistCommandExecuteHandler()
@@ -161,11 +160,11 @@ class CutlistCommandExecuteHandler(adsk.core.CommandEventHandler):
         for i in range(selection_input.selectionCount):
             selection.append(selection_input.selection(i).entity)
 
-        cutlist = CutList(user_options.cutlist)
+        cutlist = CutList(user_options.cutlist_options)
         cutlist.add(design.rootComponent, selection)
 
         fmt_class = get_format(user_options.format)
-        fmt = fmt_class(design.unitsManager, doc.name, units=user_options.unit)
+        fmt = fmt_class(design.unitsManager, doc.name, user_options.format_options)
 
         dlg = ui.createFileDialog()
         dlg.title = 'Save Cutlist'
@@ -194,13 +193,13 @@ def set_options_from_inputs(inputs: adsk.core.CommandInputs):
     material_input: adsk.core.BoolValueCommandInput = inputs.itemById('group_material')
     group_by = GroupBy(dimensions=dimensions_input.value, material=material_input.value)
 
-    user_options.cutlist.ignore_hidden = hidden_input.value
-    user_options.cutlist.ignore_external = external_input.value
-    user_options.cutlist.group_by = group_by
-    user_options.cutlist.axis_aligned = axis_aligned_input.value
-    user_options.cutlist.tolerance = tolerance_input.value
+    user_options.cutlist_options.ignore_hidden = hidden_input.value
+    user_options.cutlist_options.ignore_external = external_input.value
+    user_options.cutlist_options.group_by = group_by
+    user_options.cutlist_options.axis_aligned = axis_aligned_input.value
+    user_options.cutlist_options.tolerance = tolerance_input.value
     user_options.format = format_input.selectedItem.name
-    user_options.unit = unit_input.selectedItem.name
+    user_options.format_options.units = unit_input.selectedItem.name
 
 
 @report_errors

--- a/lib/cutlist.py
+++ b/lib/cutlist.py
@@ -25,10 +25,7 @@ class BodyPath(NamedTuple):
     def parent_name(self):
         if len(self.components) > 0:
             return self.components[-1]
-        return ""
-
-    def path_str(self, separator="/"):
-        return separator.join((*self.components, self.body_name))
+        return None
 
 
 class Dimensions(NamedTuple):

--- a/lib/format.py
+++ b/lib/format.py
@@ -2,13 +2,39 @@ import csv
 import html
 import io
 import json
+import re
 import textwrap
 import typing
+
+from dataclasses import dataclass
 
 import adsk.core
 
 from .texttable import Texttable
 from .cutlist import CutList, CutListItem
+
+
+@dataclass
+class FormatOptions:
+    """
+    Options that affect cutlist formatting.
+
+    Options:
+      component_names          use component names instead of body names
+      short_names              only use the final body or component name, rather than the full path
+      remove_numeric_suffixes  remove common numeric suffixes from names
+      unique_names             only output unique names for each item
+      include_material         include material in the output if the format supports it
+      name_separator           the separator to use when joining name elements
+      units                    the units to use for dimensions
+    """
+    component_names: bool = False
+    short_names: bool = False
+    remove_numeric_suffixes: bool = False
+    unique_names: bool = False
+    include_material: bool = True
+    name_separator: str = '/'
+    units: str = 'auto'
 
 
 class FileFilter:
@@ -25,21 +51,45 @@ class Format:
     name = 'Base Format'
     filefilter = FileFilter('Text Files', 'txt')
 
-    def __init__(self, units_manager: adsk.core.UnitsManager, docname: str, units=None):
+    def __init__(self, units_manager: adsk.core.UnitsManager, docname: str, options: FormatOptions):
         self.units_manager = units_manager
         self.docname = docname
-        self.units = units if (units and units != 'auto') else units_manager.defaultLengthUnits
+        self.options = options
+        self.units = options.unique_names if options.units != 'auto' else units_manager.defaultLengthUnits
 
     @property
-    def filename(self):
+    def filename(self) -> str:
         name = self.docname.lower().replace(' ', '_')
         return f'{name}.{self.filefilter.ext}'
 
-    def format_value(self, value, showunits=False):
+    def format_value(self, value, showunits=False) -> str:
         return self.units_manager.formatInternalValue(value, self.units, showunits)
 
-    def format_item_names(self, item: CutListItem):
-        return [p.path_str() for p in item.paths]
+    def format_item_names(self, item: CutListItem) -> list[str]:
+        separator = self.options.name_separator
+
+        names = []
+        for p in item.paths:
+            if self.options.component_names and p.parent_name:
+                if self.options.short_names:
+                    name = p.parent_name
+                else:
+                    name = separator.join(p.components)
+            else:
+                if self.options.short_names:
+                    name = p.body_name
+                else:
+                    name = separator.join((*p.components, p.body_name))
+
+            if self.options.remove_numeric_suffixes:
+                name = re.sub(r'(\s+\d+|\s*\(\d+\))$', '', name)
+
+            names.append(name)
+
+        if self.options.unique_names:
+            names = set(names)
+
+        return sorted(names)
 
     def format(self, cutlist: CutList):
         raise NotImplementedError
@@ -50,6 +100,7 @@ class JSONFormat(Format):
     filefilter = FileFilter('JSON Files', 'json')
 
     def item_to_dict(self, item: CutListItem):
+        include_material = self.options.include_material
         return {
             'count': item.count,
             'dimensions': {
@@ -58,12 +109,28 @@ class JSONFormat(Format):
                 'width': self.format_value(item.dimensions.width),
                 'height': self.format_value(item.dimensions.height),
             },
-            'material': item.material,
+            **({'material': item.material} if include_material else {}),
             'names': self.format_item_names(item),
         }
 
     def format(self, cutlist: CutList):
         return json.dumps([self.item_to_dict(item) for item in cutlist.sorted_items()], indent=2)
+
+
+class CSVDictBuilder:
+    def __init__(self, fields: list[str]):
+        self.fields = fields
+        self.index = 0
+        self.dict = {}
+
+    def set_field(self, value: str):
+        if self.index < len(self.fields):
+            field = self.fields[self.index]
+            self.dict[field] = value
+            self.index += 1
+
+    def build(self) -> dict:
+        return self.dict
 
 
 class CSVFormat(Format):
@@ -74,10 +141,11 @@ class CSVFormat(Format):
 
     @property
     def fieldnames(self):
+        include_material = self.options.include_material
         lengthkey, widthkey, heightkey = [f'{v} ({self.units})' for v in ['length', 'width', 'height']]
         return [
             'count',
-            'material',
+            *(['material'] if include_material else []),
             lengthkey,
             widthkey,
             heightkey,
@@ -85,15 +153,20 @@ class CSVFormat(Format):
         ]
 
     def item_to_dict(self, item: CutListItem):
-        fields = self.fieldnames
-        return {
-            fields[0]: item.count,
-            fields[1]: item.material,
-            fields[2]: self.format_value(item.dimensions.length),
-            fields[3]: self.format_value(item.dimensions.width),
-            fields[4]: self.format_value(item.dimensions.height),
-            fields[5]: ','.join(self.format_item_names(item)),
-        }
+        d = CSVDictBuilder(self.fieldnames)
+
+        d.set_field(item.count)
+
+        if self.options.include_material:
+            d.set_field(item.material)
+
+        d.set_field(self.format_value(item.dimensions.length))
+        d.set_field(self.format_value(item.dimensions.width))
+        d.set_field(self.format_value(item.dimensions.height))
+        d.set_field(','.join(self.format_item_names(item)))
+
+        return d.build()
+
 
     def format(self, cutlist: CutList):
         with io.StringIO(newline='') as f:
@@ -112,20 +185,35 @@ class CutlistOptimizerFormat(CSVFormat):
 
     @property
     def fieldnames(self):
-        return ['Length', 'Width', 'Qty', 'Label', 'Enabled']
+        include_material = self.options.include_material
+        return [
+            'Length',
+            'Width',
+            'Qty',
+            *(['Material'] if include_material else []),
+            'Label',
+            'Enabled',
+        ]
 
     def item_to_dict(self, item: CutListItem):
-        # Note that CutlistOptimizer uses str.split to 'parse' the fields in each record. Import will
-        # fail when fields contain the delimiter. Use semicolon to separate the names and remove all
-        # delimiters from str values.
-        fields = self.fieldnames
-        return {
-            fields[0]: self.format_value(item.dimensions.length),
-            fields[1]: self.format_value(item.dimensions.width),
-            fields[2]: item.count,
-            fields[3]: ';'.join(self.format_item_names(item)).replace(',', ''),
-            fields[4]: 'true'
-        }
+        # CutlistOptimizer uses str.split to 'parse' the fields in each record.
+        # Import will fail when fields contain the delimiter. Use semicolon to
+        # separate the names and remove all delimiters from str values.
+
+        d = CSVDictBuilder(self.fieldnames)
+
+        d.set_field(self.format_value(item.dimensions.length))
+        d.set_field(self.format_value(item.dimensions.width))
+        d.set_field(item.count)
+
+        if self.options.include_material:
+            d.set_field(item.material.replace(',', ''))
+
+        d.set_field(';'.join(n.replace(',', '') for n in self.format_item_names(item)))
+
+        d.set_field('true')
+
+        return d.build()
 
 
 class CutlistEvoFormat(CSVFormat):
@@ -140,20 +228,34 @@ class CutlistEvoFormat(CSVFormat):
 
     @property
     def fieldnames(self):
-        return ['Length', 'Width', 'Thickness', 'Quantity', 'Rotation', 'Name', 'Material', 'Banding']
+        include_material = self.options.include_material
+        return [
+            'Length',
+            'Width',
+            'Thickness',
+            'Quantity',
+            'Rotation',
+            'Name',
+            *(['Material'] if include_material else []),
+            'Banding'
+        ]
 
     def item_to_dict(self, item: CutListItem):
-        fields = self.fieldnames
-        return {
-            fields[0]: self.format_value(item.dimensions.length),
-            fields[1]: self.format_value(item.dimensions.width),
-            fields[2]: self.format_value(item.dimensions.height),
-            fields[3]: item.count,
-            fields[4]: ','.join(['L'] * item.count),
-            fields[5]: ','.join(self.format_item_names(item)),
-            fields[6]: item.material,
-            fields[7]: ','.join(['N'] * item.count),
-        }
+        d = CSVDictBuilder(self.fieldnames)
+
+        d.set_field(self.format_value(item.dimensions.length))
+        d.set_field(self.format_value(item.dimensions.width))
+        d.set_field(self.format_value(item.dimensions.height))
+        d.set_field(item.count)
+        d.set_field(','.join(['L'] * item.count))
+        d.set_field(','.join(self.format_item_names(item)))
+
+        if self.options.include_material:
+            d.set_field(item.material)
+
+        d.set_field(','.join(['N'] * item.count))
+
+        return d.build()
 
 
 class TableFormat(Format):
@@ -161,13 +263,22 @@ class TableFormat(Format):
 
     @property
     def fieldnames(self):
+        include_material = self.options.include_material
         lengthkey, widthkey, heightkey = [f'{v} ({self.units})' for v in ['length', 'width', 'height']]
-        return ['count', 'material', lengthkey, widthkey, heightkey, 'names']
+        return [
+            'count',
+            *(['material'] if include_material else []),
+            lengthkey,
+            widthkey,
+            heightkey,
+            'names',
+        ]
 
     def item_to_row(self, item: CutListItem):
+        include_material = self.options.include_material
         return [
             item.count,
-            item.material,
+            *([item.material] if include_material else []),
             self.format_value(item.dimensions.length),
             self.format_value(item.dimensions.width),
             self.format_value(item.dimensions.height),
@@ -175,11 +286,13 @@ class TableFormat(Format):
         ]
 
     def format(self, cutlist: CutList):
+        include_material = self.options.include_material
+
         tt = Texttable(max_width=0)
         tt.set_deco(Texttable.HEADER | Texttable.HLINES)
         tt.header(self.fieldnames)
-        tt.set_cols_dtype(['i', 't', 't', 't', 't', 't'])
-        tt.set_cols_align(['r', 'l', 'r', 'r', 'r', 'l'])
+        tt.set_cols_dtype(['i', *(['t'] if include_material else []), 't', 't', 't', 't'])
+        tt.set_cols_align(['r', *(['l'] if include_material else []), 'r', 'r', 'r', 'l'])
         tt.add_rows([self.item_to_row(item) for item in cutlist.sorted_items()], header=False)
         return tt.draw()
 
@@ -190,16 +303,25 @@ class HTMLFormat(Format):
 
     @property
     def fieldnames(self):
+        include_material = self.options.include_material
         lengthkey, widthkey, heightkey = [f'{v} ({self.units})' for v in ['Length', 'Width', 'Height']]
-        return ['Count', lengthkey, widthkey, heightkey, 'Material', 'Names']
+        return [
+            'Count',
+            lengthkey,
+            widthkey,
+            heightkey,
+            *(['Material'] if include_material else []),
+            'Names',
+        ]
 
     def item_to_row(self, item: CutListItem):
+        include_material = self.options.include_material
         cols = [
             item.count,
             self.format_value(item.dimensions.length),
             self.format_value(item.dimensions.width),
             self.format_value(item.dimensions.height),
-            html.escape(item.material),
+            *([html.escape(item.material)] if include_material else []),
             '<br>'.join(html.escape(n) for n in self.format_item_names(item)),
         ]
         return '<tr>' + ''.join(f'<td>{c}</td>' for c in cols) + '</tr>'


### PR DESCRIPTION
This adds several new options to control how names are formatted in the output:

* Short names - only include the component or body name, instead of the full path with parent names.
* Component names - use component names instead of body names, useful for components with a single body
* Unique names - only output unique names for each item. This is useful when you have many instances of the same body or component and only want to see the name once
* Remove numeric suffixes - trims common suffixes like ` 1` and ` (2)` from names

It also adds an option to exclude material information from the output. This is most useful for CutList Optimizer, where materials are a toggle in the UI, but might be useful for other formats. To support optional output columns, refactor the CSV formatters to make less error-prone to match up the column names with the values. The new `CSVDictBuilder` class keeps track of the inputs, so as long as you add values in the same order as the fields, everything should work.

Now that there are a bunch of formatting option, group them together in a collapsible section.

Many of these options were inspired by #30 but now apply to all formats.
Fixes #29.