### PR TITLE
Fix crash when selecting a non-default unit

### DIFF
--- a/lib/format.py
+++ b/lib/format.py
@@ -55,7 +55,7 @@ class Format:
         self.units_manager = units_manager
         self.docname = docname
         self.options = options
-        self.units = options.unique_names if options.units != 'auto' else units_manager.defaultLengthUnits
+        self.units = options.units if options.units != 'auto' else units_manager.defaultLengthUnits
 
     @property
     def filename(self) -> str:


### PR DESCRIPTION
options.unique_names (a bool) was used instead of options.units, so selecting any unit other than "auto" passed a boolean to formatInternalValue instead of a unit string, causing a TypeError.

Thanks for this cool project!

Antoine